### PR TITLE
remove Hull tags from home page signup form

### DIFF
--- a/CooperationHullMainSite/Services/ActionNetworkCalls.cs
+++ b/CooperationHullMainSite/Services/ActionNetworkCalls.cs
@@ -44,10 +44,14 @@ namespace CooperationHullMainSite.Services
 
             var tagnameList = tagsToAdd.Select(x => x.name).ToList();
 
-            if (hullTag)
-                tagnameList.Remove("Not Hull");
-            else
-                tagnameList.Remove("Hull");
+            //if (hullTag)
+            //    tagnameList.Remove("Not Hull");
+            //else
+            //    tagnameList.Remove("Hull");
+
+            //temp roemove hull / not hull tags until front end is sorted out properly.
+            tagnameList.Remove("Not Hull");
+            tagnameList.Remove("Hull");
 
             string endpoint = $"people/";
             var temp = await PostDataAPICall(endpoint, new ActionNetworkPersonSignupHelper(formData, tagnameList));


### PR DESCRIPTION
Removed both the Hull and Not Hull tags from the list on the home page signup form until we get around to sorting out the front end properly.