### PR TITLE
Fix social media icons on blog post page footer

### DIFF
--- a/CooperationHullMainSite/Views/Shared/_footer.cshtml
+++ b/CooperationHullMainSite/Views/Shared/_footer.cshtml
@@ -10,13 +10,13 @@
         </div>
         <div class="footer-socials">
             <a href="https://www.facebook.com/profile.php?id=100092856802621" target="_blank" rel="noopener noreferrer">
-                <img src="./assets/img/icon-fb.svg" alt="facebook icon" />
+                <img src="/assets/img/icon-fb.svg" alt="facebook icon" />
             </a>
             <a href="https://www.instagram.com/cooperation.hull/" target="_blank" rel="noopener noreferrer">
-                <img src="./assets/img/icon-ig.svg" alt="instagram icon" />
+                <img src="/assets/img/icon-ig.svg" alt="instagram icon" />
             </a>
             <a href="https://www.youtube.com/@@CooperationHull" target="_blank" rel="noopener noreferrer">
-                <img src="./assets/img/icon-yt.svg" alt="youTube icon" />
+                <img src="/assets/img/icon-yt.svg" alt="youTube icon" />
             </a>
         </div>
     </div>


### PR DESCRIPTION
Minor tweak to stop social media icons vanishing on footer on blog post pages.